### PR TITLE
Introduce ApartmentFilter and update frontend query params

### DIFF
--- a/backend/apps/apartments/filters.py
+++ b/backend/apps/apartments/filters.py
@@ -1,0 +1,14 @@
+import django_filters
+
+from .models import Apartment
+
+
+class ApartmentFilter(django_filters.FilterSet):
+    price_min = django_filters.NumberFilter(field_name="price", lookup_expr="gte")
+    price_max = django_filters.NumberFilter(field_name="price", lookup_expr="lte")
+    rooms = django_filters.NumberFilter(field_name="number_of_rooms")
+    available = django_filters.BooleanFilter(field_name="availability")
+
+    class Meta:
+        model = Apartment
+        fields = ["price_min", "price_max", "rooms", "available"]

--- a/backend/apps/apartments/views.py
+++ b/backend/apps/apartments/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import action
 
 from .models import Apartment
+from .filters import ApartmentFilter
 from .serializers import (
     ApartmentListSerializer,
     ApartmentDetailSerializer,
@@ -23,11 +24,7 @@ class ApartmentViewSet(viewsets.ModelViewSet):
     queryset = Apartment.objects.all().order_by('-created_at')
     lookup_field = 'slug'
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
-    filterset_fields = {
-        'availability': ['exact'],
-        'number_of_rooms': ['exact'],
-        'price': ['gte', 'lte'],
-    }
+    filterset_class = ApartmentFilter
     search_fields = ['name', 'description']
 
     def get_permissions(self):

--- a/frontend/src/components/Apartments/ApartmentsList.vue
+++ b/frontend/src/components/Apartments/ApartmentsList.vue
@@ -101,10 +101,10 @@ async function fetchApartments(page = 1) {
   try {
     const params = {
       page,
-      ...(filters.value.priceFrom && { price__gte: filters.value.priceFrom }),
-      ...(filters.value.priceTo && { price__lte: filters.value.priceTo }),
-      ...(filters.value.rooms && { number_of_rooms: filters.value.rooms }),
-      ...(filters.value.availability && { availability: true }),
+      ...(filters.value.priceFrom && { price_min: filters.value.priceFrom }),
+      ...(filters.value.priceTo && { price_max: filters.value.priceTo }),
+      ...(filters.value.rooms && { rooms: filters.value.rooms }),
+      ...(filters.value.availability && { available: true }),
       ...(filters.value.search && { search: filters.value.search }),
     }
 


### PR DESCRIPTION
## Summary
- create `ApartmentFilter` mapping custom param names to model fields
- use the new filter class in `ApartmentViewSet`
- update frontend apartment list query to send `price_min`, `price_max`, `rooms`, and `available`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b8f451a88323b481e9b7dde02d58